### PR TITLE
Fix HTTP Basic authentication

### DIFF
--- a/python-midonetclient/src/midonetclient/auth_lib.py
+++ b/python-midonetclient/src/midonetclient/auth_lib.py
@@ -52,7 +52,7 @@ class Auth:
 
         if _sem.acquire(blocking=False):
             try:
-                auth = base64.encodestring(self.username + ':' + self.password)
+                auth = base64.b64encode(self.username + ':' + self.password)
                 headers = {'Authorization': 'Basic ' + auth}
 
                 if self.project_id is not None:


### PR DESCRIPTION
Python's base64.encodestring inserts newlines to strings to make them
nicely formatted. This however, is not compatible with the http basic
authentication, so long passwords will not authenticate properly.

For example, for the following credentials:

    self.username = 'midonet'
    self.password = ('9TfcTqxJyWx5tFz4dwh49VXBFqhJcczTGg7hMfbZpVSK5hpcKFKnr7Xq'
                     'K4dd8V4Y')

Doing it with encode string yields:

    'bWlkb25ldDo5VGZjVHF4SnlXeDV0Rno0ZHdoNDlWWEJGcWhKY2N6VEdnN2hNZmJacFZTSzVocGNL\nRktucjdYcUs0ZGQ4VjRZ\n'

Note the two '\n' above, one for length and one for termination.

Using base64.b64encode yields the same as curl:

    'bWlkb25ldDo5VGZjVHF4SnlXeDV0Rno0ZHdoNDlWWEJGcWhKY2N6VEdnN2hNZmJacFZTSzVocGNLRktucjdYcUs0ZGQ4VjRZ'

    root@cadi:~# curl --user
    midonet:9TfcTqxJyWx5tFz4dwh49VXBFqhJcczTGg7hMfbZpVSK5hpcKFKnr7XqK4dd8V4Y
    http://127.0.0.1:8080/midonet-api/login -H "X-Auth-Project: services"
    {"key":"f2cfe1e86f1e467ba294ceacb5d17599","expires":"Tue, 12-05-2015 13:55:05
    GMT"}root@cadi:~# curl --user
    midonet:9TfcTqxJyWx5tFz4dwh49VXBFqhJcczTGg7hMfbZpVSK5hpcKFKnr7XqK4dd8V4Y
    http://127.0.0.1:8080/midonet-api/login -H "X-Auth-Project: services"
    --verbose
    * Hostname was NOT found in DNS cache
    * *   Trying 127.0.0.1...
    * * Connected to 127.0.0.1 (127.0.0.1) port 8080 (#0)
    * * Server auth using Basic with user 'midonet'
    * > GET /midonet-api/login HTTP/1.1
    * > Authorization: Basic
    bWlkb25ldDo5VGZjVHF4SnlXeDV0Rno0ZHdoNDlWWEJGcWhKY2N6VEdnN2hNZmJacFZTSzVocGNLRktucjdYcUs0ZGQ4VjRZ

Fix MNA-334

Change-Id: Ia92a490c881d176c747203c23baf5c15282e76e0